### PR TITLE
Fix method for retrieving canvas ID from manifest

### DIFF
--- a/hxat/requirements/test.txt
+++ b/hxat/requirements/test.txt
@@ -7,4 +7,5 @@ pytest-env==0.6.2
 iso8601==0.1.12
 mock==4.0.2
 responses==0.10.11
+requests-mock==1.9.3
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,14 +48,16 @@ def course_instructor_factory(user_profile_factory):
 
 @pytest.fixture
 def assignment_target_factory():
-    def _assignment_target_factory(course):
+    def _assignment_target_factory(course, **kwargs):
         target_object = TargetObject.objects.create(
-            target_title="{} Title".format(uuid.uuid4().hex),
-            target_author="John {}".format(uuid.uuid4().int),
+            target_title=kwargs.get("target_title", "{} Title".format(uuid.uuid4().hex)),
+            target_author=kwargs.get("target_author", "John {}".format(uuid.uuid4().int)),
+            target_type=kwargs.get("target_type", "tx"),
+            target_content=kwargs.get("target_content", ""),
         )
         assignment = Assignment.objects.create(
             course=course,
-            assignment_name="Assignment {}".format(uuid.uuid4().hex),
+            assignment_name=kwargs.get("assignment_name", "Assignment {}".format(uuid.uuid4().hex)),
             pagination_limit=settings.ANNOTATION_PAGINATION_LIMIT_DEFAULT,
             # default from settings, this is set by UI
             annotation_database_url=settings.ANNOTATION_DB_URL,
@@ -63,7 +65,10 @@ def assignment_target_factory():
             annotation_database_secret_token=settings.ANNOTATION_DB_SECRET_TOKEN,
         )
         assignment_target = AssignmentTargets.objects.create(
-            assignment=assignment, target_object=target_object, order=1,
+            assignment=assignment,
+            target_object=target_object,
+            order=1,
+            target_external_options=kwargs.get("target_external_options"),
         )
         return assignment_target
 

--- a/tests/hx_lti_assignment/test_models.py
+++ b/tests/hx_lti_assignment/test_models.py
@@ -1,0 +1,50 @@
+import pytest
+from unittest import mock
+
+from hx_lti_assignment.models import AssignmentTargets
+from hx_lti_initializer.models import LTICourse
+
+
+@pytest.mark.parametrize('status_code', [404, 500])
+@pytest.mark.django_db
+def test_AssignmentTargets_get_canvas_id_for_mirador_manifest_not_found(user_profile_factory, assignment_target_factory, requests_mock, status_code):
+    """
+    Checks that if the mirador manifest returns an HTTP error response, then
+    the canvas ID will be returned as None.
+    """
+    manifest_url = "http://localhost:8000/non-existent/manifest.json"
+    instructor = user_profile_factory(roles=["Instructor"])
+    course_object = LTICourse.create_course("test_course_id", instructor)
+    assignment_target = assignment_target_factory(
+        course_object,
+        target_type="ig",
+        target_content=manifest_url,
+        target_external_options="ImageView,,false,,,",
+    )
+
+    requests_mock.get(manifest_url, status_code=status_code, text='')
+    canvas_id = assignment_target.get_canvas_id_for_mirador()
+    assert requests_mock.called
+    assert canvas_id is None
+
+@pytest.mark.django_db
+def test_AssignmentTargets_get_canvas_id_for_mirador_manifest_returns_canvas_id_in_options(user_profile_factory, assignment_target_factory, requests_mock):
+    """
+    Checks that if a canvas ID is explicitly set in the target options, it is returned immediately
+    without querying the manifest.
+    """
+    manifest_url = "http://localhost:8000/valid/manifest.json"
+    expected_canvas_id = "3123"
+    instructor = user_profile_factory(roles=["Instructor"])
+    course_object = LTICourse.create_course("test_course_id", instructor)
+    assignment_target = assignment_target_factory(
+        course_object,
+        target_type="ig",
+        target_content=manifest_url,
+        target_external_options=f"ImageView,{expected_canvas_id},false,,,",
+    )
+
+    requests_mock.get(manifest_url, status_code=200, text='')
+    actual_canvas_id = assignment_target.get_canvas_id_for_mirador()
+    assert not requests_mock.called
+    assert actual_canvas_id == expected_canvas_id


### PR DESCRIPTION
This PR ensures that the image annotation UI doesn't break if the IIIF manifest can't be retrieved or parsed. 

By default, the tool will retrieve the manifest and extract the ID of the image that should be displayed in Mirador (i.e. the canvas ID). The problem is that if the request fails (e.g. HTTP 404, 500), then it will raise a `JSONDecodeError` which is shown to the user as a generic _Internal Server Error_. This PR fixes that so any errors are caught when retrieving/parsing the manifest.

Changes:
- Refactored `get_canvas_id_for_mirador()` method to simplify the logic and ensure that any errors in the request, parsing, or extraction phases are handled. 
- Added basic `pytest` tests to ensure this is the actual behavior.
- Annotated the `AssignmentTargets` model to describe the content of the `target_external_options` field, which was being used in `get_canvas_id_for_mirador()` to determine whether a `canvas_id` was already configured or if a request to the manifest needed to be made.
