### PR TITLE
Update IMM SDK to v0.2.0

### DIFF
--- a/hxat/requirements/base.txt
+++ b/hxat/requirements/base.txt
@@ -19,4 +19,4 @@ requests==2.23.0
 python_dotenv==0.14.0
 Twisted==20.3.0
 WhiteNoise==5.2.0
-git+https://github.com/Harvard-ATG/media_management_sdk.git@v0.1.0#egg=media_management_sdk==0.1.0
+git+https://github.com/Harvard-ATG/media_management_sdk.git@v0.2.0#egg=media_management_sdk==0.2.0

--- a/image_store/backends.py
+++ b/image_store/backends.py
@@ -37,14 +37,18 @@ class IMMImageStoreBackend(ImageStoreBackend):
     Collaborates with the Image Media Manager (IMM) service to store images
     and generate IIIF manifests.
 
-    See also: https://github.com/harvard-atg/media_management_api
-
     Notes:
-    - IMM requires client credentials (client key and secret) to authenticate and obtain a
-      temporary access token for the logged-in user.
-    - Requires LTI context_id and tool_consumer_instance_guid to identify the course library.
-    - Additional LTI attributes are provided when creating a new course library.
-    - A manifest can be obtained for a collection with images.
+    - API client credentials (`client_id` and `client_secret`) are required to authenticate.
+    - LTI attributes (`context_id` and `tool_consumer_instance_guid`) are required to
+      identify the image library for the course. If the image library does not exist,
+      it will be created.
+    - Images must be uploaded to a "collection" associated with the image library, which can 
+      then be represented as a IIIF manifest.
+    - The user uploading the image must be identified by their SIS ID.
+
+    See also: 
+        - https://github.com/harvard-atg/media_management_api
+        - https://github.com/harvard-atg/media_management_sdk
     """
 
     def __init__(self, config=None, lti_params=None):


### PR DESCRIPTION
This PR bumps `media_management_sdk` to release [v0.2.0](https://github.com/Harvard-ATG/media_management_sdk/releases/tag/v0.2.0). 

Notes:
- No other changes are required to the `hxat` since the updates are internal to the library and related API endpoints. As far as the `hxat` is concerned, the public interface and usage pattern is the same. 
- This has been deployed to the DEV environment and appears to be working as intended (client authenticates with JWTs).
