### PR TITLE
Fix preview uri

### DIFF
--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -562,26 +562,15 @@ class DashboardAnnotations(object):
         if media_type == "image":
             index = object_id.find("/canvas/")
             trimmed_object_id = object_id if index == -1 else object_id[0:index]
-            # trimmed_object_id = object_id[
-            #     0 : object_id.find("/canvas/")
-            # ]  # only use regex if absolutely necessary
-            # logger.info(f"self.target_objects_by_content={self.target_objects_by_content.keys()}")
-            logger.info(f"trimmed_object_id={trimmed_object_id}")
-            # checks for anything that contains the root trimmed_object_id or root url if its an image
-            object_key = self.target_objects_by_content.get(trimmed_object_id, None)
-            if object_key:
-                target_id = object_key["id"]
-            # logger.info(f"")
-            # for key in self.target_objects_by_content:
-            #     # logger.info(f"trimmed_object_id={trimmed_object_id} key.lower()={key.lower()}")
-            #     if key.lower() == trimmed_object_id:
-            #         target_id = self.target_objects_by_content[key]["id"]
-            #         break
+            
+            # checks for anything that contains the trimmed_object_id or  if its an image
+            dict_object = self.target_objects_by_content.get(trimmed_object_id, None)
+            if dict_object:
+                target_id = dict_object["id"]
         else:
             if object_id in self.target_objects_by_id:
                 target_id = object_id
-        if not target_id:
-            logger.info(f" object_id={object_id}")
+
         return target_id
 
     def get_assignment_name(self, annotation):

--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -563,7 +563,7 @@ class DashboardAnnotations(object):
             index = object_id.find("/canvas/")
             trimmed_object_id = object_id if index == -1 else object_id[0:index]
             
-            # checks for anything that contains the trimmed_object_id or  if its an image
+            # gets the data dict from the target_objects_by_content dictionary by trimmed_object_id else assign None
             dict_object = self.target_objects_by_content.get(trimmed_object_id, None)
             if dict_object:
                 target_id = dict_object["id"]

--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -503,7 +503,6 @@ class DashboardAnnotations(object):
             if x["target_type"] == "ig"
         }
         self.preview_url_cache = {}
-
     def get_annotations_by_id(self):
         return get_annotations_keyed_by_annotation_id(self.annotations)
 
@@ -554,23 +553,35 @@ class DashboardAnnotations(object):
                 )
         return users
 
+    """
+    Edge cases for get_target_id function that can cause bugs from external manifest uri:
+        Capital Letters in the URI can cause errors when doing lookups
+        object_id=https://digital.library.villanova.edu/item/vudl:92879/Manifest
+        target_objects_by_content key=https://digital.library.villanova.edu/Item/vudl:92879/Manifest
+        
+    Note: local testing(local hxat and catchpy database) of these URI fails, will need to revisit if bugs pop up in the future
+        Assignments using New highlighter images will only store the URI that has "Canvas" or "canvas" in catchpy.
+        While the old highlighter will store the manifest URI in addition to the canvas URI
+        New Highlighter:
+        object_id=https://digital.library.villanova.edu/Item/vudl:92879/Canvas/p0
+        target_objects_by_content key=https://digital.library.villanova.edu/Item/vudl:92879/Manifest
+    """
     def get_target_id(self, media_type, object_id):
         object_id = str(
             object_id
-        ).lower()  # ensure we have the target id as a string, not an int
+        ) # ensure we have the target id as a string, not an int
         target_id = ""
         if media_type == "image":
-            index = object_id.find("/canvas/")
+            found = object_id.find("/canvas/")
+            # in case there is capital letters in the URI
+            index = found if found is not -1 else object_id.find("/Canvas/")
             trimmed_object_id = object_id if index == -1 else object_id[0:index]
-            
             # gets the data dict from the target_objects_by_content dictionary by trimmed_object_id else assign None
-            dict_object = self.target_objects_by_content.get(trimmed_object_id, None)
-            if dict_object:
-                target_id = dict_object["id"]
+            if trimmed_object_id in self.target_objects_by_content:
+                target_id = self.target_objects_by_content[trimmed_object_id]["id"]
         else:
             if object_id in self.target_objects_by_id:
                 target_id = object_id
-
         return target_id
 
     def get_assignment_name(self, annotation):
@@ -603,6 +614,7 @@ class DashboardAnnotations(object):
 
         if media_type == "image":
             target_id = self.get_target_id(media_type, annotation["manifest_url"])
+            logger.info(f"canvas in={'/canvas/' in  annotation['manifest_url']}")
         else:
             target_id = annotation["uri"]
 

--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -560,16 +560,28 @@ class DashboardAnnotations(object):
         ).lower()  # ensure we have the target id as a string, not an int
         target_id = ""
         if media_type == "image":
-            trimmed_object_id = object_id[
-                0 : object_id.find("/canvas/")
-            ]  # only use regex if absolutely necessary
+            index = object_id.find("/canvas/")
+            trimmed_object_id = object_id if index == -1 else object_id[0:index]
+            # trimmed_object_id = object_id[
+            #     0 : object_id.find("/canvas/")
+            # ]  # only use regex if absolutely necessary
+            # logger.info(f"self.target_objects_by_content={self.target_objects_by_content.keys()}")
+            logger.info(f"trimmed_object_id={trimmed_object_id}")
             # checks for anything that contains the root trimmed_object_id or root url if its an image
-            for key in self.target_objects_by_content:
-                if key.lower().startswith(trimmed_object_id):
-                    target_id = self.target_objects_by_content[key]["id"]
+            object_key = self.target_objects_by_content.get(trimmed_object_id, None)
+            if object_key:
+                target_id = object_key["id"]
+            # logger.info(f"")
+            # for key in self.target_objects_by_content:
+            #     # logger.info(f"trimmed_object_id={trimmed_object_id} key.lower()={key.lower()}")
+            #     if key.lower() == trimmed_object_id:
+            #         target_id = self.target_objects_by_content[key]["id"]
+            #         break
         else:
             if object_id in self.target_objects_by_id:
                 target_id = object_id
+        if not target_id:
+            logger.info(f" object_id={object_id}")
         return target_id
 
     def get_assignment_name(self, annotation):

--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -555,14 +555,10 @@ class DashboardAnnotations(object):
 
     """
     Edge cases for get_target_id function that can cause bugs from external manifest uri:
-        Capital Letters in the URI can cause errors when doing lookups
-        object_id=https://digital.library.villanova.edu/item/vudl:92879/Manifest
-        target_objects_by_content key=https://digital.library.villanova.edu/Item/vudl:92879/Manifest
-        
-    Note: local testing(local hxat and catchpy database) of these URI fails, will need to revisit if bugs pop up in the future
+    Note: local testing(hxat and catchpy database) of these URI fails, will need to revisit if bugs pop up in the future
         Assignments using New highlighter images will only store the URI that has "Canvas" or "canvas" in catchpy.
         While the old highlighter will store the manifest URI in addition to the canvas URI
-        New Highlighter:
+        New Highlighter example data:
         object_id=https://digital.library.villanova.edu/Item/vudl:92879/Canvas/p0
         target_objects_by_content key=https://digital.library.villanova.edu/Item/vudl:92879/Manifest
     """

--- a/tests/hx_lti_initializer/test_lti_utils.py
+++ b/tests/hx_lti_initializer/test_lti_utils.py
@@ -1,10 +1,11 @@
 import pytest
 from requests.sessions import session
-from hx_lti_initializer.utils import _fetch_annotations_by_course
+from hx_lti_initializer.utils import _fetch_annotations_by_course, DashboardAnnotations
 import requests
 import requests_mock
 from testing_data import build_json
 from uuid import uuid4
+from unittest.mock import patch
 
 context_id = f"{uuid4()}"
 annotator_auth_token = f"{uuid4()}"
@@ -43,3 +44,42 @@ def test_fetch_annotations_by_course_failing():
         requests_mocker.get(request_url, json={"rows":data,"total":len(data)})
         r = _fetch_annotations_by_course(context_id, annotation_db_url, annotator_auth_token)
         assert r == expected_response
+
+def test_dashboard_annotations_success_image_uri():
+    target_objects_by_content = built_json["test_dashboard_annotations_success"]
+    # override DashboardAnnotations __init__
+    def __init__(self, request, annotations):
+        self.target_objects_by_content = target_objects_by_content
+
+    with patch.object(DashboardAnnotations, '__init__', __init__):
+        da = DashboardAnnotations("", {})
+        assert da.get_target_id('image', 'https://d.lib.ncsu.edu/collections/catalog/nubian-message-1992-11-30/manifest/661') == 15
+
+def test_dashboard_annotations_success_image_similar_uri():
+    target_objects_by_content = built_json["test_dashboard_annotations_success"]
+    def __init__(self, request, annotations):
+        self.target_objects_by_content = target_objects_by_content
+
+    with patch.object(DashboardAnnotations, '__init__', __init__):
+        da = DashboardAnnotations("", {})
+        assert da.get_target_id('image', 'https://d.lib.ncsu.edu/collections/catalog/nubian-message-1992-11-30/manifest/662') == 16
+
+def test_dashboard_annotations_success_image_capital_letter_uri():
+    target_objects_by_content = built_json["test_dashboard_annotations_success"]
+    def __init__(self, request, annotations):
+        self.target_objects_by_content = target_objects_by_content
+
+    with patch.object(DashboardAnnotations, '__init__', __init__):
+        da = DashboardAnnotations("", {})
+        assert da.get_target_id('image', 'https://digital.library.villanova.edu/Item/vudl:92879/Manifest') == 9
+
+# TODO: Fix how we store and match up canvas URI with manifest URI
+# Note: test fails because we cant match any of the keys in the target_objects_by_content
+# even if the root URI is similar to a matching manifest
+def test_dashboard_annotations_failing_image_canvas_uri():
+    target_objects_by_content = built_json["test_dashboard_annotations_success"]
+    def __init__(self, request, annotations):
+        self.target_objects_by_content = target_objects_by_content
+    with patch.object(DashboardAnnotations, '__init__', __init__):
+        da = DashboardAnnotations("", {})
+        assert da.get_target_id('image', 'https://digital.library.villanova.edu/Item/vudl:92879/Canvas/p0') == ""

--- a/tests/hx_lti_initializer/test_lti_utils.py
+++ b/tests/hx_lti_initializer/test_lti_utils.py
@@ -74,12 +74,12 @@ def test_dashboard_annotations_success_image_capital_letter_uri():
         assert da.get_target_id('image', 'https://digital.library.villanova.edu/Item/vudl:92879/Manifest') == 9
 
 # TODO: Fix how we store and match up canvas URI with manifest URI
-# Note: test fails because we cant match any of the keys in the target_objects_by_content
-# even if the root URI is similar to a matching manifest
-def test_dashboard_annotations_failing_image_canvas_uri():
-    target_objects_by_content = built_json["test_dashboard_annotations_success"]
-    def __init__(self, request, annotations):
-        self.target_objects_by_content = target_objects_by_content
-    with patch.object(DashboardAnnotations, '__init__', __init__):
-        da = DashboardAnnotations("", {})
-        assert da.get_target_id('image', 'https://digital.library.villanova.edu/Item/vudl:92879/Canvas/p0') == ""
+# Note: test fails in e2e testing because we cant match any of the keys in the target_objects_by_content served up by catchpy
+# Data from catchpy sometimes does not include a manifest uri
+# def test_dashboard_annotations_success_image_canvas_uri():
+#     target_objects_by_content = built_json["test_dashboard_annotations_success"]
+#     def __init__(self, request, annotations):
+#         self.target_objects_by_content = target_objects_by_content
+#     with patch.object(DashboardAnnotations, '__init__', __init__):
+#         da = DashboardAnnotations("", {})
+#         assert da.get_target_id('image', 'https://digital.library.villanova.edu/Item/vudl:92879/Canvas/p0') == "some_id"

--- a/tests/hx_lti_initializer/testing_data.py
+++ b/tests/hx_lti_initializer/testing_data.py
@@ -251,6 +251,46 @@ def build_json(id, context_id):
                     "totalReplies": "0"
                 },
                 "expected_response": {"rows": [], "totalCount": 1}
+            },
+            "test_dashboard_annotations_success": {
+                "https://iiif.bodleian.ox.ac.uk/iiif/manifest/60834383-7146-41ab-bfe1-48ee97bc04be.json":
+                    {
+                    "id": 14,
+                    "target_title": "bodleian",
+                    "target_content":
+                        "https://iiif.bodleian.ox.ac.uk/iiif/manifest/60834383-7146-41ab-bfe1-48ee97bc04be.json",
+                    "target_type": "ig",
+                    },
+                "https://d.lib.ncsu.edu/collections/catalog/nubian-message-1992-11-30/manifest/661":
+                    {
+                    "id": 15,
+                    "target_title": "nubian-message-1992",
+                    "target_content":
+                        "https://d.lib.ncsu.edu/collections/catalog/nubian-message-1992-11-30/manifest/661",
+                    "target_type": "ig",
+                    },
+                "https://d.lib.ncsu.edu/collections/catalog/nubian-message-1992-11-30/manifest/662":
+                    {
+                    "id": 16,
+                    "target_title": "nubian-message-1992",
+                    "target_content":
+                        "https://d.lib.ncsu.edu/collections/catalog/nubian-message-1992-11-30/manifest/662",
+                    "target_type": "ig",
+                    },
+                "https://digital.library.villanova.edu/Item/vudl:92879/Manifest": {
+                    "id": 9,
+                    "target_title": "test old",
+                    "target_content":
+                    "https://digital.library.villanova.edu/Item/vudl:92879/Manifest",
+                    "target_type": "ig",
+                },
+                "https://damsssl.llgc.org.uk/iiif/2.0/4389767/manifest.json": {
+                    "id": 12,
+                    "target_title": "test old2",
+                    "target_content":
+                    "https://damsssl.llgc.org.uk/iiif/2.0/4389767/manifest.json",
+                    "target_type": "ig",
+                }
             }
         }
     return testing_data_dict


### PR DESCRIPTION
PR from Dojo:
- Fixes the issue where Dashboards would incorrectly load the wrong data object for an annotation

Notes:        
- Removed the `.toLower()`  on the `object_id` due to a change in the `get_target_id` function

Edge case for `get_target_id` function that can cause bugs from external manifest URI(seems to only error when testing locally hxat and catchpy):
- Assignments using New highlighter images will only store the URI that contains the string "Canvas" or "canvas" in catchpy, while the old highlighter will store the manifest URI in addition to the canvas URI
New Highlighter example that would fail to find the corresponding `target_id`:
`object_id`=https://digital.library.villanova.edu/Item/vudl:92879/Canvas/p0
`target_objects_by_content dict key`=https://digital.library.villanova.edu/Item/vudl:92879/Manifest
Note: that this object_id should correctly be associated with the dict key in the example but will fail due to the raw data sent from catchpy and parsed in hxat