### PR TITLE
Grade passback logging

### DIFF
--- a/annotation_store/store.py
+++ b/annotation_store/store.py
@@ -237,7 +237,7 @@ class AnnotationStore(object):
                 )
             else:
                 self.logger.error(
-                    "LTI grade request failed: description=%s lti_log_data=%s" % (outcome.description, lti_log_data)
+                    "LTI grade request failed: status_code=%s response=%s description=%s lti_log_data=%s" % (outcome.response_code, outcome.post_response.content, outcome.description, lti_log_data)
                 )
             self.outcome = outcome
         except Exception as e:
@@ -578,7 +578,7 @@ class CatchStoreBackend(StoreBackend):
                 )
             else:
                 self.logger.error(
-                    "LTI grade request failed: description=%s lti_log_data=%s" % (outcome.description, lti_log_data)
+                    "LTI grade request failed: status_code=%s response=%s description=%s lti_log_data=%s" % (outcome.response_code, outcome.post_response.content, outcome.description, lti_log_data)
                 )
             self.outcome = outcome
         except Exception as e:
@@ -857,7 +857,7 @@ class WebAnnotationStoreBackend(StoreBackend):
                 )
             else:
                 self.logger.error(
-                    "LTI grade request failed: description=%s lti_log_data=%s" % (outcome.description, lti_log_data)
+                    "LTI grade request failed: status_code=%s response=%s description=%s lti_log_data=%s" % (outcome.response_code, outcome.post_response.content, outcome.description, lti_log_data)
                 )
             self.outcome = outcome
         except Exception as e:

--- a/annotation_store/store.py
+++ b/annotation_store/store.py
@@ -214,29 +214,34 @@ class AnnotationStore(object):
     def lti_grade_passback(self, score=1.0):
         if score < 0 or score > 1.0 or isinstance(score, str):
             return
+
         tool_provider = self._get_tool_provider()
         if not tool_provider.is_outcome_service():
             self.logger.debug(
                 "LTI consumer does not expect a grade for the current user and assignment"
             )
             return
-        self.logger.info("Initiating LTI Grade Passback: score=%s" % score)
+
+        lti_log_data = {
+            k:tool_provider.launch_params.get(k)
+            for k in ('context_id', 'user_id', 'lis_outcome_service_url', 'lis_result_sourcedid', 'launch_presentation_return_url')
+        }
+
+        self.logger.info("LTI grade request initiating passback: score=%s lti_log_data=%s" % (score, lti_log_data))
         try:
             outcome = tool_provider.post_replace_result(score)
             self.logger.info(vars(outcome))
             if outcome.is_success():
                 self.logger.info(
-                    "LTI grade request was successful. Description: %s"
-                    % outcome.description
+                    "LTI grade request was successful: description=%s lti_log_data=%s" % (outcome.description, lti_log_data)
                 )
             else:
                 self.logger.error(
-                    "LTI grade request failed. Description: %s" % outcome.description
+                    "LTI grade request failed: description=%s lti_log_data=%s" % (outcome.description, lti_log_data)
                 )
             self.outcome = outcome
         except Exception as e:
-            self.logger.error("LTI post_replace_result request failed: %s" % str(e))
-        return self.outcome
+            self.logger.error("LTI grade request post_replace_result failed exception=%s lti_log_data=%s" % (str(e), lti_log_data))
 
 
 ###########################################################
@@ -550,28 +555,34 @@ class CatchStoreBackend(StoreBackend):
     def lti_grade_passback(self, score=1.0):
         if score < 0 or score > 1.0 or isinstance(score, str):
             return
+
         tool_provider = self._get_tool_provider()
         if not tool_provider.is_outcome_service():
             self.logger.debug(
                 "LTI consumer does not expect a grade for the current user and assignment"
             )
             return
-        self.logger.info("Initiating LTI Grade Passback: score=%s" % score)
+
+        lti_log_data = {
+            k:tool_provider.launch_params.get(k)
+            for k in ('context_id', 'user_id', 'lis_outcome_service_url', 'lis_result_sourcedid', 'launch_presentation_return_url')
+        }
+
+        self.logger.info("LTI grade request initiating passback: score=%s lti_log_data=%s" % (score, lti_log_data))
         try:
             outcome = tool_provider.post_replace_result(score)
             self.logger.info(vars(outcome))
             if outcome.is_success():
                 self.logger.info(
-                    "LTI grade request was successful. Description: %s"
-                    % outcome.description
+                    "LTI grade request was successful: description=%s lti_log_data=%s" % (outcome.description, lti_log_data)
                 )
             else:
                 self.logger.error(
-                    "LTI grade request failed. Description: %s" % outcome.description
+                    "LTI grade request failed: description=%s lti_log_data=%s" % (outcome.description, lti_log_data)
                 )
             self.outcome = outcome
         except Exception as e:
-            self.logger.error("LTI post_replace_result request failed: %s" % str(e))
+            self.logger.error("LTI grade request post_replace_result failed exception=%s lti_log_data=%s" % (str(e), lti_log_data))
 
 
 class WebAnnotationStoreBackend(StoreBackend):
@@ -830,22 +841,27 @@ class WebAnnotationStoreBackend(StoreBackend):
                 "LTI consumer does not expect a grade for the current user and assignment"
             )
             return
-        self.logger.info("Initiating LTI Grade Passback: score=%s" % score)
+
+        lti_log_data = {
+            k:tool_provider.launch_params.get(k)
+            for k in ('context_id', 'user_id', 'lis_outcome_service_url', 'lis_result_sourcedid', 'launch_presentation_return_url')
+        }
+
+        self.logger.info("LTI grade request initiating passback: score=%s lti_log_data=%s" % (score, lti_log_data))
         try:
             outcome = tool_provider.post_replace_result(score)
             self.logger.info(vars(outcome))
             if outcome.is_success():
                 self.logger.info(
-                    "LTI grade request was successful. Description: %s"
-                    % outcome.description
+                    "LTI grade request was successful: description=%s lti_log_data=%s" % (outcome.description, lti_log_data)
                 )
             else:
                 self.logger.error(
-                    "LTI grade request failed. Description: %s" % outcome.description
+                    "LTI grade request failed: description=%s lti_log_data=%s" % (outcome.description, lti_log_data)
                 )
             self.outcome = outcome
         except Exception as e:
-            self.logger.error("LTI post_replace_result request failed: %s" % str(e))
+            self.logger.error("LTI grade request post_replace_result failed exception=%s lti_log_data=%s" % (str(e), lti_log_data))
 
     def send_annotation_notification(self, message_type, annotation):
         # target_source_id from session guarantees it's a sequential integer id from


### PR DESCRIPTION
This PR updates the info logging for grade passback so that if an error occurs, we can more quickly locate the course/user that is experiencing the issue and start debugging.

Changes:
- Updated the `lti_grade_passback()` method so that all info log statements follow the general format of `LTI grade request ... lti_log_data=DICT`.
- There are 3 classes that implement that method: `StoreBackend`, `CatchStoreBackend`, `WebAnnotationStoreBackend`. It's unclear why the method is duplicated in all 3 classes, but that should be revisited (out of scope to refactor in this PR).

Launch parameters included for debugging:
- `context_id`: maps to the `LTICourse.course_id` Django model, so we can use this to identify the specific course that is using the tool. 
- `user_id`: maps to the `LTIProfile.anon_id` Django model, so we can use this to identify the specific user initiating the request, or at the very least tell if it's the same user or a different user.
- `lis_outcome_service_url` and `lis_result_sourcedid`: these are specific to the outcome request and show where the tool is POSTing the grade to. Not sure how useful they will be.
- `launch_presentation_return_url`: this is not strictly necessary, but may be useful to identify the originating canvas course without using a canvas-specific launch parameter (since this tool is used in edX too). Per the [LTI v1.1 spec](http://www.imsglobal.org/specs/ltiv1p1/implementation-guide) this is the _Fully qualified URL where the TP can redirect the user back to the TC interface._ In Canvas, this will look something like this: `https://canvas.harvard.edu/courses/:COURSE_ID/external_content/success/external_tool_redirect`.

Outcome response data:
- In addition to the launch parameters added to the log for context, we can also get at the underlying POST response that is sent to Canvas. This is tucked away in the `OutcomeResponse` object which is returned from the `tool_provider.post_replace_result(score)` call. 
- See the [post_outcome_request()](https://github.com/pylti/lti/blob/c4df80ae6b1a9ba3098009f31f48c44182478e78/src/lti/outcome_request.py#L130) method in `lti.outcome_request.OutcomeRequest`.
