### PR TITLE
Username not found error log 

### DIFF
--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -103,6 +103,9 @@ def launch_lti(request):
     roles = request.LTI["launch_params"][settings.LTI_ROLES]
     logger.debug("DEBUG - user logging in with roles: " + str(roles))
 
+    # this is the short, human readable label for the course context
+    context_label = request.LTI["launch_params"].get("context_label", "")
+
     # This is the name that we will show on the UI if provided...
     # EDX-NOTE: edx does not return the person's name!
     display_name = request.LTI["launch_params"].get("lis_person_name_full", None)
@@ -118,7 +121,7 @@ def launch_lti(request):
         try:
             lti_profile = LTIProfile.objects.get(anon_id=str(course))
         except LTIProfile.DoesNotExist:
-            logger.error("username({}) not found.".format(course))
+            logger.error("username({}) not found for context({})".format(course, context_label))
             raise PermissionDenied("username not found in LTI launch")
         except MultipleObjectsReturned as e:
             logger.error(


### PR DESCRIPTION
This PR updates the `username(...) not found` error message so that it includes additional context about the course.

This is a rare error, but we did see a half dozen examples of it in splunk prior to the start of the semester (Aug 15-18th), and it would be good to be able to track it down the next time it happens. The addition of the `context_label` to the error log should help with that (we're using `context_label` to avoid being too Canvas-specific here). The original thought was that this was happening because of the _Student View_ function in Canvas, but this doesn't appear to be the case because Canvas sends `lis_person_name_full=Test Student` in the launch, which would negate this particular log event from happening.

For reference, here are the relevant lines in the view:

https://github.com/Harvard-ATG/hxat/blob/a67b0e1a90d10a34866de52cba5ebbad759e2177/hx_lti_initializer/views.py#L120-L125

Note that `str(course)` in the code evaluates to the LTI `context_id`, which in Canvas is just an opaque string (e.g. `79fa0a82f14fec6e719ef58cee17eac5072ac47c`) that is not easily tied back to the canvas course ID. 